### PR TITLE
Fix missing Norwegian language configuration

### DIFF
--- a/languages/config.json
+++ b/languages/config.json
@@ -8,5 +8,10 @@
     "name": "Test template",
     "country-code": "US",
     "filename": "test.json"
+  },
+  {
+    "name": "Norwegian",
+    "country-code": "NO",
+    "filename": "norwegian.json"
   }
 ]

--- a/languages/norwegian.json
+++ b/languages/norwegian.json
@@ -7,7 +7,7 @@
       "Sensurer Bilde",
       "Avsensurer Bilde",
       "Ett verktøy som muliggjør generering av sensurering av bilder, hvor den originale dataen forblir ivaretatt i bildet.",
-      "Bare bruk sensureringsfunksjonen for å generere ett bilde, lett til passord, og do er good to go.",
+      "Bare bruk sensureringsfunksjonen for å generere ett bilde, lett til passord, og du er good to go.",
       "For å avsensurere ett bilde, bare velg bildet, skriv inn passordet, og det originale bildet blir lastet ned!",
       "Alt dette skjer lokalt på din maskin, så ingen bilder sendes til serveren din, slik at ditt personvern ivaretas.",
       "Notis: Dette verktøyet er ikke magi, så kun bilder som originalt ble sensurert med dette verktøyet vil være i stand til å gjenopprettes med dette verktøyet.",


### PR DESCRIPTION
## Summary
- correct a typo in `norwegian.json`
- add Norwegian translation to `config.json`

## Testing
- `node -e "const fs=require('fs'); const path='languages'; fs.readdirSync(path).filter(f=>f.endsWith('.json')).forEach(f=>{try{JSON.parse(fs.readFileSync(path+'/'+f,'utf8')); console.log(f+': ok');}catch(e){console.error(f+':',e.message);}});"`

------
https://chatgpt.com/codex/tasks/task_e_6842f78f69c883308a1ad8b7d01115bb